### PR TITLE
Corrected spelling for 'const port'

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require("express");
 const fetch = require("node-fetch");
 
 const app = express();
-const port = proccess.env.port || 3000;
+const port = process.env.PORT || 3000;
 
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());


### PR DESCRIPTION
'const port = process.env.PORT || 3000'